### PR TITLE
Make JsonRpcRequest struct and fields public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,11 +54,11 @@ pub type JrpcResult = Result<JsonRpcResponse, JsonRpcResponse>;
 
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
-struct JsonRpcRequest {
-    id: i64,
-    jsonrpc: String,
-    method: String,
-    params: Value,
+pub struct JsonRpcRequest {
+    pub id: i64,
+    pub jsonrpc: String,
+    pub method: String,
+    pub params: Value,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
I have a situation where I am receiving requests that may or may not be in JSON-RPC format at the same route, so I need to be able to optionally parse to a `JsonRpcRequest`.