### PR TITLE
fix: add error key for error responses

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -19,7 +19,7 @@ async fn main() {
 
     let router = Router::new().route("/", post(handler));
 
-    tracing::debug!("listening");
+    tracing::debug!("listening on 127.0.0.1:8080");
     axum::Server::bind(&"127.0.0.1:8080".parse().unwrap())
         .serve(router.into_make_service())
         .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,7 @@ where
 /// A JSON-RPC response.
 pub struct JsonRpcResponse {
     jsonrpc: String,
+    #[serde(flatten)]
     pub result: JsonRpcAnswer,
     /// The request ID.
     id: i64,
@@ -215,7 +216,7 @@ impl IntoResponse for JsonRpcResponse {
 }
 
 #[derive(Serialize, Debug, Deserialize, PartialEq, Eq)]
-#[serde(untagged)]
+#[serde(rename_all = "lowercase")]
 /// JsonRpc [response object](https://www.jsonrpc.org/specification#response_object)
 pub enum JsonRpcAnswer {
     Result(Value),


### PR DESCRIPTION
Hey @0xdeafbeef 

Minor PR to add the "error" key to responses.
https://www.jsonrpc.org/specification 

```json
{
    "jsonrpc": "2.0",
    "error": {
        "code": -32601,
        "message": "Method `sdf` not found",
        "data": null
    },
    "id": 1
}
```